### PR TITLE
change dns lookup policy

### DIFF
--- a/agent/test.go
+++ b/agent/test.go
@@ -47,6 +47,8 @@ func main() {
 		return
 	}
 
+	fmt.Printf("%s current\n", time.Now())
+
 	//add a listener
 	l, err := c.AddListener("www.baidu.com", conf)
 	if err != nil {
@@ -67,16 +69,16 @@ func main() {
 	//get endpoint
 	endpoint, err := l.GetEndpoint()
 	if err != nil {
-		fmt.Printf("get endpoint failed %v %v\n", l, err)
+		fmt.Printf("first get endpoint failed %v %v\n", l, err)
 		return
 	}
-	fmt.Printf("endpoint = %v\n", endpoint)
+	fmt.Printf("first endpoint = %v\n", endpoint)
 
 	//get endpoint again
 	endpoint, err = l.GetEndpoint()
 	if err != nil {
-		fmt.Printf("get endpoint failed %v %v\n", l, err)
+		fmt.Printf("second get endpoint failed %v %v\n", l, err)
 		return
 	}
-	fmt.Printf("endpoint = %v\n", endpoint)
+	fmt.Printf("second endpoint = %v\n", endpoint)
 }

--- a/entry.go
+++ b/entry.go
@@ -98,7 +98,19 @@ func (m *entryManger) launch(entries []*types.Endpoint) {
 		}
 	}
 
-	//TODO clean
+	for k := range m.launchedQueue {
+		hit := false
+		for _, e := range entries {
+			if k == e.ToString() {
+				hit = true
+			}
+		}
+
+		if !hit {
+			m.checker.UnRegister(k)
+			delete(m.launchedQueue, k)
+		}
+	}
 }
 
 func (m *entryManger) enqueue(dsts []*types.Endpoint) {

--- a/internal/worker_queue/pool.go
+++ b/internal/worker_queue/pool.go
@@ -9,6 +9,13 @@ import (
 	"time"
 )
 
+const (
+	defaultBatches      = 2
+	defaultBatchTimeout = 5
+	defaultCleanTimeout = 2 * defaultBatchTimeout
+	defaultCleanMax     = 5 * defaultBatches
+)
+
 type PoolConfig struct {
 	Batches      int
 	BatchTimeout int
@@ -34,6 +41,22 @@ type WorkerPool struct {
 }
 
 func NewWorkerPool(ctx context.Context, config *PoolConfig) (*WorkerPool, error) {
+	if config.Batches == 0 {
+		config.Batches = defaultBatches
+	}
+
+	if config.BatchTimeout == 0 {
+		config.BatchTimeout = defaultBatchTimeout
+	}
+
+	if config.CleanTimeout == 0 {
+		config.CleanTimeout = defaultCleanTimeout
+	}
+
+	if config.CleanMax == 0 {
+		config.CleanMax = defaultCleanMax
+	}
+
 	p := &WorkerPool{
 		ctx:                ctx,
 		config:             config,

--- a/scout/custom/config.go
+++ b/scout/custom/config.go
@@ -5,5 +5,7 @@ import (
 )
 
 type CustomCheckerConfig struct {
-	Probe worker_queue.WatcherFunc
+	Probe        worker_queue.WatcherFunc
+	Batches      int
+	BatchTimeout int
 }

--- a/scout/custom/custom.go
+++ b/scout/custom/custom.go
@@ -28,11 +28,8 @@ func NewCustomChecker(config *scout.ModelConfig) (*customChecker, error) {
 	}
 
 	poolConf := &worker_queue.PoolConfig{
-		Batches:      2,
-		BatchTimeout: 5,
-
-		CleanTimeout: 2,
-		CleanMax:     2,
+		Batches:      conf.Batches,
+		BatchTimeout: conf.BatchTimeout,
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
In the previous version, the resolving request was initiated after a sleep cycle. After this modification, the resolving process will be executed immediately.